### PR TITLE
Set UTF-8 encoding via HTTP header in main files

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,12 +1,12 @@
 <?php
 require __DIR__ . '/config.php';
 $user = current_user();
+header('Content-Type: text/html; charset=utf-8');
 ?>
 <!doctype html>
 <html lang="en">
 
 <head>
-	<meta charset="utf-8">
 	<title>Welcome - <?= htmlspecialchars($APP_NAME) ?></title>
 	<link rel="stylesheet" href="assets/css/style.css">
 </head>

--- a/partials/header.php
+++ b/partials/header.php
@@ -1,12 +1,13 @@
 <?php
 require_once __DIR__ . '/../config.php';
 $user = current_user();
+// Ensure UTF-8 via HTTP header
+header('Content-Type: text/html; charset=utf-8');
 ?>
 <!doctype html>
 <html lang="en">
 
 <head>
-	<meta charset="utf-8">
 	<title><?= htmlspecialchars($APP_NAME) ?></title>
 	<link rel="stylesheet" href="<?= $BASE_URL ?>/assets/css/style.css">
 	<script src="<?= $BASE_URL ?>/assets/js/app.js" defer></script>


### PR DESCRIPTION
Moved UTF-8 charset declaration from HTML meta tag to HTTP header in index.php and partials/header.php to ensure proper character encoding. Removed redundant <meta charset> tags.